### PR TITLE
desktop: AirPods ear detection and Wayland session fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788018247,
-        "narHash": "sha256-G/zxdo0VOXTKP+p3l3vUbzqUFlZmmXKvh0maaqoA5Wk=",
+        "lastModified": 1788028600,
+        "narHash": "sha256-/tndYl5hKvzMoPxsssRGGwH9Am+HD2xg3ixqZfmGDo0=",
         "owner": "lorenzolfm",
         "repo": "claude-tray",
-        "rev": "da0976292e4b5628f0290fb50d96addcdc2c824c",
+        "rev": "d3e62ef81acb32cd7700846e1971a9bf110928ff",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787926460,
-        "narHash": "sha256-Rf2+5+ACRsI0xBicCraxsBtfSaQ93Br0Nr22nWimkS4=",
+        "lastModified": 1787993548,
+        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "04ceec130b3a935d01584d4b1a68a366919674a9",
+        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
         "type": "github"
       },
       "original": {
@@ -539,11 +539,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787957042,
-        "narHash": "sha256-qvmgmXXK3YtmjGCz38A5ZovIW3JUtoRZXlV46NTWwLc=",
+        "lastModified": 1787997185,
+        "narHash": "sha256-oNOlNXe+7DteA5vgAkbs9L5Skrr4ptF77Wq3S0WYSHI=",
         "owner": "lorenzolfm",
         "repo": "wt",
-        "rev": "295e8a0ae156e5d5b82de61fad849745ab97db80",
+        "rev": "cf71b4d84b0f51094a95f5db3e1b6711ae5f6a24",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -19,7 +19,7 @@
     },
     "cl-nix-lite": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nixpkgs": "nixpkgs",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
@@ -59,7 +59,47 @@
         "type": "github"
       }
     },
+    "claude-tray": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788008149,
+        "narHash": "sha256-10jtNMfaI90TBXpZ750OpI9WTRbeMfeWI8D7pRF1Jpc=",
+        "owner": "lorenzolfm",
+        "repo": "claude-tray",
+        "rev": "5a61351d492477cea2ecf05af8dc5e209445c4e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lorenzolfm",
+        "repo": "claude-tray",
+        "type": "github"
+      }
+    },
     "crane": {
+      "locked": {
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
       "locked": {
         "lastModified": 1787326676,
         "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
@@ -117,6 +157,24 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
         "lastModified": 1765835352,
         "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
@@ -130,9 +188,9 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1787559586,
@@ -228,6 +286,21 @@
     },
     "nixpkgs-lib": {
       "locked": {
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
@@ -241,7 +314,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_2": {
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1785031560,
         "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
@@ -323,6 +396,7 @@
     "root": {
       "inputs": {
         "claude-code": "claude-code",
+        "claude-tray": "claude-tray",
         "darwin": "darwin",
         "mac-app-util": "mac-app-util",
         "nix-homebrew": "nix-homebrew",
@@ -455,8 +529,8 @@
     },
     "wt": {
       "inputs": {
-        "crane": "crane",
-        "flake-parts": "flake-parts_2",
+        "crane": "crane_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.lock
+++ b/flake.lock
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788008149,
-        "narHash": "sha256-10jtNMfaI90TBXpZ750OpI9WTRbeMfeWI8D7pRF1Jpc=",
+        "lastModified": 1788018247,
+        "narHash": "sha256-G/zxdo0VOXTKP+p3l3vUbzqUFlZmmXKvh0maaqoA5Wk=",
         "owner": "lorenzolfm",
         "repo": "claude-tray",
-        "rev": "5a61351d492477cea2ecf05af8dc5e209445c4e8",
+        "rev": "da0976292e4b5628f0290fb50d96addcdc2c824c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
     wt.url = "github:lorenzolfm/wt";
     wt.inputs.nixpkgs.follows = "nixpkgs";
     wt.inputs.rust-overlay.follows = "rust-overlay";
+    claude-tray.url = "github:lorenzolfm/claude-tray";
+    claude-tray.inputs.nixpkgs.follows = "nixpkgs";
+    claude-tray.inputs.rust-overlay.follows = "rust-overlay";
   };
 
   outputs =
@@ -29,12 +32,20 @@
       rust-overlay,
       sops-nix,
       wt,
+      claude-tray,
       ...
     }@inputs:
     {
       nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        specialArgs = { inherit claude-code rust-overlay wt; };
+        specialArgs = {
+          inherit
+            claude-code
+            rust-overlay
+            wt
+            claude-tray
+            ;
+        };
         modules = [
           ./hosts/desktop/configuration.nix
           sops-nix.nixosModules.sops

--- a/hosts/desktop/claude-tray.nix
+++ b/hosts/desktop/claude-tray.nix
@@ -1,0 +1,67 @@
+{ lib, ... }:
+
+# Autostart for the Claude Code session tray applet (~/Projects/misc/claude-tray).
+#
+# The applet publishes a StatusNotifierItem so the state of many concurrent Claude Code sessions
+# is ambient in Waybar. Waybar needs no configuration change: its `tray` module is already in
+# `modules-right`, and an SNI item joins it simply by existing on the session bus.
+#
+# Why a user service and not a Hyprland `exec-once`: the failure this whole effort exists to
+# prevent is a session indicator that quietly disappears. `exec-once` gives no restart and no
+# journal; a unit gives both. Read it with `journalctl --user -u claude-tray`.
+
+let
+  home = "/home/lorenzo";
+in
+{
+  systemd.user.services.claude-tray = {
+    description = "Claude Code session tray applet";
+    documentation = [ "https://github.com/lorenzolfm/claude-tray" ];
+
+    # The session bus is the only real prerequisite. This deliberately does NOT order itself
+    # after Waybar: Waybar is a Hyprland `exec-once` and therefore always starts later than the
+    # user manager, so waiting for it is impossible by construction. The applet instead calls
+    # ksni's `assume_sni_available`, which turns "no tray host yet" into a wait and re-registers
+    # the item whenever a host appears — at first login and after every Waybar restart alike.
+    requires = [ "dbus.socket" ];
+    after = [ "dbus.socket" ];
+
+    # `graphical-session.target` would be the tidier binding, but it only activates under the
+    # UWSM-managed session; a plain `hyprland` login leaves it dead, which would silently mean
+    # no tray at all. The applet needs no compositor anyway — it is a D-Bus service.
+    wantedBy = [ "default.target" ];
+
+    # 🔴 NixOS gives user units a sanitized PATH (coreutils, findutils, grep, sed, systemd), so
+    # the manager's own PATH from /etc/environment.d does NOT reach the service. Both binaries
+    # the applet shells out to would be missing. Neither is pinned to a store path on purpose:
+    #   - claude-agents, so the producer can be upgraded underneath the applet;
+    #   - zellij, because click-to-jump speaks to a running server and a pinned build of a
+    #     different version would talk to it wrongly. It must be the same zellij he runs.
+    environment.PATH = lib.mkForce (
+      lib.concatStringsSep ":" [
+        "${home}/.nix-profile/bin"
+        "/etc/profiles/per-user/lorenzo/bin"
+        "/run/current-system/sw/bin"
+      ]
+    );
+
+    serviceConfig = {
+      # Installed with `nix profile add .` from the claude-tray checkout, the same way
+      # `claude-agents` itself is installed.
+      ExecStart = "${home}/.nix-profile/bin/claude-tray";
+      Restart = "always";
+      RestartSec = 5;
+    };
+
+    unitConfig = {
+      # Every user with a systemd manager gets this unit — including gdm-greeter at the login
+      # screen. Only Lorenzo has the applet or a bar to put it in.
+      ConditionUser = "lorenzo";
+      ConditionPathExists = "${home}/.nix-profile/bin/claude-tray";
+
+      # Never give up. A rate limit here would turn a bad minute into a permanently empty bar,
+      # which is the exact failure this unit exists to rule out.
+      StartLimitIntervalSec = 0;
+    };
+  };
+}

--- a/hosts/desktop/claude-tray.nix
+++ b/hosts/desktop/claude-tray.nix
@@ -1,19 +1,27 @@
-{ lib, ... }:
+{
+  lib,
+  pkgs,
+  claude-tray,
+  ...
+}:
 
-# Autostart for the Claude Code session tray applet (~/Projects/misc/claude-tray).
+# The Claude Code session tray applet (github.com/lorenzolfm/claude-tray): which sessions are
+# waiting on you, as a glyph and a count in Waybar, with the list one click away.
 #
-# The applet publishes a StatusNotifierItem so the state of many concurrent Claude Code sessions
-# is ambient in Waybar. Waybar needs no configuration change: its `tray` module is already in
-# `modules-right`, and an SNI item joins it simply by existing on the session bus.
+# Waybar needs no configuration change — its `tray` module is already in `modules-right`, and an
+# SNI item joins it simply by existing on the session bus.
 #
-# Why a user service and not a Hyprland `exec-once`: the failure this whole effort exists to
-# prevent is a session indicator that quietly disappears. `exec-once` gives no restart and no
-# journal; a unit gives both. Read it with `journalctl --user -u claude-tray`.
+# Why a user service and not a Hyprland `exec-once`: the failure this applet exists to prevent is
+# a session indicator that quietly disappears. `exec-once` gives no restart and no journal; a unit
+# gives both. Read it with `journalctl --user -u claude-tray`.
 
 let
-  home = "/home/lorenzo";
+  package = claude-tray.packages.${pkgs.stdenv.hostPlatform.system}.default;
 in
 {
+  # Also on PATH, so it can be run and debugged by hand.
+  environment.systemPackages = [ package ];
+
   systemd.user.services.claude-tray = {
     description = "Claude Code session tray applet";
     documentation = [ "https://github.com/lorenzolfm/claude-tray" ];
@@ -32,32 +40,31 @@ in
     wantedBy = [ "default.target" ];
 
     # 🔴 NixOS gives user units a sanitized PATH (coreutils, findutils, grep, sed, systemd), so
-    # the manager's own PATH from /etc/environment.d does NOT reach the service. Both binaries
-    # the applet shells out to would be missing. Neither is pinned to a store path on purpose:
-    #   - claude-agents, so the producer can be upgraded underneath the applet;
+    # the manager's own PATH from /etc/environment.d does NOT reach the service, and both
+    # binaries the applet shells out to would be missing. Neither is looked up by store path on
+    # purpose:
+    #   - claude-agents, so the producer can be upgraded underneath the applet. ⚠️ It is still
+    #     an imperative `nix profile` install, which is why ~/.nix-profile/bin is on this list.
     #   - zellij, because click-to-jump speaks to a running server and a pinned build of a
     #     different version would talk to it wrongly. It must be the same zellij he runs.
     environment.PATH = lib.mkForce (
       lib.concatStringsSep ":" [
-        "${home}/.nix-profile/bin"
+        "/home/lorenzo/.nix-profile/bin"
         "/etc/profiles/per-user/lorenzo/bin"
         "/run/current-system/sw/bin"
       ]
     );
 
     serviceConfig = {
-      # Installed with `nix profile add .` from the claude-tray checkout, the same way
-      # `claude-agents` itself is installed.
-      ExecStart = "${home}/.nix-profile/bin/claude-tray";
+      ExecStart = lib.getExe package;
       Restart = "always";
       RestartSec = 5;
     };
 
     unitConfig = {
       # Every user with a systemd manager gets this unit — including gdm-greeter at the login
-      # screen. Only Lorenzo has the applet or a bar to put it in.
+      # screen. Only Lorenzo has a bar to put it in.
       ConditionUser = "lorenzo";
-      ConditionPathExists = "${home}/.nix-profile/bin/claude-tray";
 
       # Never give up. A rate limit here would turn a bad minute into a permanently empty bar,
       # which is the exact failure this unit exists to rule out.

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -6,6 +6,7 @@
     ./hardware-configuration.nix
     ./backup.nix
     ./scb-repo.nix
+    ./claude-tray.nix
   ];
 
   nixpkgs.overlays = [

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -106,6 +106,15 @@
     alsa.support32Bit = true;
     pulse.enable = true;
     jack.enable = true;
+    # LibrePods (and any AVRCP peer) needs a registered player to accept
+    # play/pause/skip. WirePlumber supplies one itself; bluez's mpris-proxy
+    # is the PulseAudio-era equivalent and the two conflict, so use this
+    # and keep mpris-proxy off.
+    wireplumber.extraConfig."51-bluez-avrcp" = {
+      "monitor.bluez.properties" = {
+        "bluez5.dummy-avrcp-player" = true;
+      };
+    };
   };
 
   users.users.lorenzo = {

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -90,6 +90,11 @@
 
   services.xserver.enable = true;
   services.xserver.displayManager.gdm.enable = true;
+  # Hyprland installs two sessions; the plain one bypasses UWSM, so
+  # graphical-session.target never activates and the portals stay dead
+  # (GTK apps then ignore color-scheme and render light). Pre-select the
+  # uwsm-managed session so a login can't silently land on the broken one.
+  services.displayManager.defaultSession = "hyprland-uwsm";
   services.xserver.desktopManager.gnome.enable = true;
   services.xserver.xkb = {
     layout = "us";

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -11,6 +11,23 @@
 
   nixpkgs.overlays = [
     (final: _prev: { sparrow = final.callPackage ../../pkgs/sparrow/package.nix { }; })
+    # librepods decides whether the AirPods are the active output by substring
+    # matching the default sink's name. WirePlumber 0.5.13 changed how it formats
+    # those names, so the match silently fails and ear detection stops pausing
+    # media -- the events still fire, the pause is just never reached.
+    # 0001 is upstream PR #417 (open, unmerged), comparing the bluez
+    # `device.string` MAC exactly instead. 0002 guards a NULL deref that PR
+    # leaves in its new callback. Drop both once #417 reaches nixpkgs.
+    (_final: prev: {
+      librepods = prev.librepods.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [
+          ../../pkgs/librepods/0001-match-sinks-by-mac-not-name.patch
+          ../../pkgs/librepods/0002-guard-null-sink-info.patch
+        ];
+        # The patches are rooted at the repo, but sourceRoot is source/linux.
+        patchFlags = [ "-p2" ];
+      });
+    })
   ];
 
   boot.loader.systemd-boot.enable = true;
@@ -143,6 +160,7 @@
     jellyfin-desktop
     libevent
     libnotify
+    librepods
     libsystemtap
     linuxPackages.perf
     obs-studio

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -155,6 +155,11 @@
     ];
   };
 
+  # Qt defaults to the xcb platform plugin and aborts under Hyprland, where
+  # there is no X display. Prefer wayland, keeping xcb as fallback for Qt
+  # apps built without the wayland plugin.
+  environment.sessionVariables.QT_QPA_PLATFORM = "wayland;xcb";
+
   environment.systemPackages = with pkgs; [
     (appimage-run.override {
       extraPkgs = pkgs: [ pkgs.xorg.libxshmfence ];

--- a/pkgs/librepods/0001-match-sinks-by-mac-not-name.patch
+++ b/pkgs/librepods/0001-match-sinks-by-mac-not-name.patch
@@ -1,0 +1,158 @@
+diff --git a/linux/main.cpp b/linux/main.cpp
+index 94d341ea3..64317d2c4 100644
+--- a/linux/main.cpp
++++ b/linux/main.cpp
+@@ -105,8 +105,7 @@ class AirPodsTrayApp : public QObject {
+                 // On startup after reboot, activate A2DP profile for already connected AirPods
+                 QTimer::singleShot(2000, this, [this, address]()
+                 {
+-                    QString formattedAddress = address.toString().replace(":", "_");
+-                    mediaController->setConnectedDeviceMacAddress(formattedAddress);
++                    mediaController->setConnectedDeviceMacAddress(address.toString());
+                     mediaController->activateA2dpProfile();
+                     LOG_INFO("A2DP profile activation attempted for AirPods found on startup");
+                 });
+@@ -427,7 +426,7 @@ public slots:
+         if (areAirpodsConnected() && m_deviceInfo && !m_deviceInfo->bluetoothAddress().isEmpty())
+         {
+             LOG_INFO("AirPods already connected after wake-up, re-activating A2DP profile");
+-            mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress().replace(":", "_"));
++            mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress());
+ 
+             // Always activate A2DP profile after system wake since the profile might have been lost
+             QTimer::singleShot(1000, this, [this]()
+@@ -494,9 +493,7 @@ private slots:
+         {
+             if (!address.isEmpty())
+             {
+-                QString formattedAddress = address;
+-                formattedAddress = formattedAddress.replace(":", "_");
+-                mediaController->setConnectedDeviceMacAddress(formattedAddress);
++                mediaController->setConnectedDeviceMacAddress(address);
+                 mediaController->activateA2dpProfile();
+                 LOG_INFO("A2DP profile activation attempted for newly connected device");
+             }
+@@ -738,7 +735,7 @@ private slots:
+         {
+             parseMetadata(data);
+             initiateMagicPairing();
+-            mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress().replace(":", "_"));
++            mediaController->setConnectedDeviceMacAddress(m_deviceInfo->bluetoothAddress());
+             if (m_deviceInfo->getEarDetection()->oneOrMorePodsInEar()) // AirPods get added as output device only after this
+             {
+                 mediaController->activateA2dpProfile();
+diff --git a/linux/media/mediacontroller.cpp b/linux/media/mediacontroller.cpp
+index 078129c5a..06091bd55 100644
+--- a/linux/media/mediacontroller.cpp
++++ b/linux/media/mediacontroller.cpp
+@@ -95,9 +95,9 @@ void MediaController::followMediaChanges() {
+ }
+ 
+ bool MediaController::isActiveOutputDeviceAirPods() {
+-  QString defaultSink = m_pulseAudio->getDefaultSink();
+-  LOG_DEBUG("Default sink: " << defaultSink);
+-  return defaultSink.contains(connectedDeviceMacAddress);
++  QString defaultSinkMacAddress = m_pulseAudio->getDefaultSinkMacAddress();
++  LOG_DEBUG("Default sink MAC address: " << defaultSinkMacAddress);
++  return defaultSinkMacAddress == connectedDeviceMacAddress;
+ }
+ 
+ void MediaController::handleConversationalAwareness(const QByteArray &data) {
+diff --git a/linux/media/pulseaudiocontroller.cpp b/linux/media/pulseaudiocontroller.cpp
+index d1535d0ee..299626162 100644
+--- a/linux/media/pulseaudiocontroller.cpp
++++ b/linux/media/pulseaudiocontroller.cpp
+@@ -105,11 +105,60 @@ QString PulseAudioController::getDefaultSink()
+         waitForOperation(op);
+         pa_operation_unref(op);
+     }
++
+     pa_threaded_mainloop_unlock(m_mainloop);
+ 
+     return data.sinkName;
+ }
+ 
++QString PulseAudioController::getDefaultSinkMacAddress() {
++    return this->getMacAddressBySinkName(this->getDefaultSink());
++}
++
++QString PulseAudioController::getMacAddressBySinkName(const QString &sinkName)
++{
++    if (!m_initialized) return QString();
++
++    struct CallbackData {
++        QString sinkMacAddress;
++        pa_threaded_mainloop *mainloop;
++    } data;
++    data.mainloop = m_mainloop;
++
++    auto callback = [](pa_context *c, const pa_sink_info *info, int eol, void *userdata)
++    {
++        CallbackData *d = static_cast<CallbackData*>(userdata);
++        if (eol > 0)
++        {
++            pa_threaded_mainloop_signal(d->mainloop, 0);
++            return;
++        }
++
++        const char *addr = pa_proplist_gets(
++        info->proplist,
++        "device.string"
++        );
++
++        if (addr)
++        {
++            d->sinkMacAddress = QString::fromUtf8(addr);
++            pa_threaded_mainloop_signal(d->mainloop, 0);
++        }
++    };
++
++    pa_threaded_mainloop_lock(m_mainloop);
++    pa_operation *op = pa_context_get_sink_info_by_name(m_context, sinkName.toUtf8().constData(), callback, &data);
++    if (op)
++    {
++        waitForOperation(op);
++        pa_operation_unref(op);
++    }
++
++    pa_threaded_mainloop_unlock(m_mainloop);
++
++    return data.sinkMacAddress;
++}
++
+ int PulseAudioController::getSinkVolume(const QString &sinkName)
+ {
+     if (!m_initialized) return -1;
+@@ -215,8 +264,10 @@ QString PulseAudioController::getCardNameForDevice(const QString &macAddress)
+         }
+         if (info)
+         {
+-            QString name = QString::fromUtf8(info->name);
+-            if (name.startsWith("bluez") && name.contains(d->targetMac))
++            const QString name = QString::fromUtf8(info->name);
++            const QString macAddress = pa_proplist_gets(info->proplist, "device.string");
++
++            if (d->targetMac == macAddress)
+             {
+                 d->cardName = name;
+                 pa_threaded_mainloop_signal(d->mainloop, 0);
+diff --git a/linux/media/pulseaudiocontroller.h b/linux/media/pulseaudiocontroller.h
+index 9ee1b2793..807e07467 100644
+--- a/linux/media/pulseaudiocontroller.h
++++ b/linux/media/pulseaudiocontroller.h
+@@ -15,6 +15,7 @@ class PulseAudioController : public QObject
+ 
+     bool initialize();
+     QString getDefaultSink();
++    QString getDefaultSinkMacAddress();
+     int getSinkVolume(const QString &sinkName);
+     bool setSinkVolume(const QString &sinkName, int volumePercent);
+     bool setCardProfile(const QString &cardName, const QString &profileName);
+@@ -32,6 +33,7 @@ class PulseAudioController : public QObject
+     static void serverInfoCallback(pa_context *c, const pa_server_info *info, void *userdata);
+ 
+     bool waitForOperation(pa_operation *op);
++    QString getMacAddressBySinkName(const QString &sinkName);
+ };
+ 
+ #endif // PULSEAUDIOCONTROLLER_H

--- a/pkgs/librepods/0002-guard-null-sink-info.patch
+++ b/pkgs/librepods/0002-guard-null-sink-info.patch
@@ -1,0 +1,16 @@
+--- a/linux/media/pulseaudiocontroller.cpp
++++ b/linux/media/pulseaudiocontroller.cpp
+@@ -128,7 +128,12 @@
+     auto callback = [](pa_context *c, const pa_sink_info *info, int eol, void *userdata)
+     {
+         CallbackData *d = static_cast<CallbackData*>(userdata);
+-        if (eol > 0)
++        // eol > 0 ends the list; eol < 0 signals an error and PulseAudio
++        // passes info == NULL with it, so both must signal and bail before
++        // touching info. Without this a failed lookup dereferences NULL --
++        // which is exactly what happens when the default sink disappears
++        // mid-reconnect.
++        if (eol != 0 || !info)
+         {
+             pa_threaded_mainloop_signal(d->mainloop, 0);
+             return;


### PR DESCRIPTION
Four independent desktop fixes, one per commit — each stands alone and can be read in order.

| Commit | What |
| --- | --- |
| `feat: add librepods, patched to match sinks by MAC` | AirPods ear detection / noise control / battery on Linux, with two carried patches (upstream PR #417 + a NULL guard) so sink matching compares the bluez MAC instead of a WirePlumber-formatted sink name. |
| `fix: register a dummy AVRCP player for bluez` | Without a registered MPRIS player, bluez drops the play/pause AirPods send, so ear detection had nothing to act on. Uses WirePlumber's own dummy player rather than bluez `mpris-proxy` (the two conflict). |
| `fix: pre-select the uwsm-managed hyprland session` | GDM offers two Hyprland sessions; the non-UWSM one never activates `graphical-session.target`, leaving the portals dead and GTK apps rendering light. |
| `fix: prefer the wayland qt platform plugin` | Qt defaults to xcb and aborts under Hyprland; xcb stays as fallback. |

The librepods patches are meant to be temporary — drop the overlay once upstream #417 reaches nixpkgs.

Verified with `nix eval --impure .#nixosConfigurations.nixos.config.system.build.toplevel.drvPath` (evaluates clean; the `services.xserver.displayManager.gdm.enable` rename warning is pre-existing).

Note: this branch also carries the three `claude-tray` commits that were sitting unpushed on local `main`.