### PR TITLE
desktop: claude-ps as a system package, plus librepods/ghostty/AVRCP fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /local-secrets/
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -19,7 +19,7 @@
     },
     "cl-nix-lite": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
@@ -59,7 +59,7 @@
         "type": "github"
       }
     },
-    "claude-tray": {
+    "claude-ps": {
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
@@ -71,11 +71,36 @@
         ]
       },
       "locked": {
-        "lastModified": 1788041280,
-        "narHash": "sha256-6d2Dre9CH2vppqPKfSSXEXtsJqj1urrYvv2Qde5Pslo=",
+        "lastModified": 1788063168,
+        "narHash": "sha256-102+uIKx+QjJvCb0RagBP93yL1bjBbk+7ps36hogYs4=",
+        "owner": "lorenzolfm",
+        "repo": "claude-ps",
+        "rev": "f092e0d2ced84d0d69320aeeec71a0cf21ae1287",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lorenzolfm",
+        "repo": "claude-ps",
+        "type": "github"
+      }
+    },
+    "claude-tray": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788063204,
+        "narHash": "sha256-tDAOGHl2AfjPS7gCqaS9BaOkUFjc9qKci77A6Nr3vCc=",
         "owner": "lorenzolfm",
         "repo": "claude-tray",
-        "rev": "e2b87e31d3aeae617d06b1575ddf7fd403f4399d",
+        "rev": "5b81aa376826c9f61ed30fda6a4def63731a4cef",
         "type": "github"
       },
       "original": {
@@ -100,6 +125,21 @@
       }
     },
     "crane_2": {
+      "locked": {
+        "lastModified": 1787326676,
+        "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "692f7e9ef2ece8125b466f66f2af532b3edaed0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_3": {
       "locked": {
         "lastModified": 1787326676,
         "narHash": "sha256-lWhBbBvC05/xwivKBBiM2YNizpmgqCgyOIzomvRuwxs=",
@@ -175,6 +215,24 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
         "lastModified": 1765835352,
         "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
@@ -188,9 +246,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
         "lastModified": 1787559586,
@@ -301,6 +359,21 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_3": {
+      "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
@@ -314,7 +387,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_4": {
       "locked": {
         "lastModified": 1785031560,
         "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
@@ -379,11 +452,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1787736819,
-        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -396,6 +469,7 @@
     "root": {
       "inputs": {
         "claude-code": "claude-code",
+        "claude-ps": "claude-ps",
         "claude-tray": "claude-tray",
         "darwin": "darwin",
         "mac-app-util": "mac-app-util",
@@ -413,11 +487,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787993548,
-        "narHash": "sha256-+IAEnmmx5YIhUWo0lp15jLLHchnXo5yKgWsi6C6Cf+0=",
+        "lastModified": 1788077403,
+        "narHash": "sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4+7Ur4icKssD4Wc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "996e9b0b019a4a9eb9e9a5641aefa06d801b5895",
+        "rev": "89e26eeaafa88a2ede4778734acc794ff0299beb",
         "type": "github"
       },
       "original": {
@@ -529,8 +603,8 @@
     },
     "wt": {
       "inputs": {
-        "crane": "crane_2",
-        "flake-parts": "flake-parts_3",
+        "crane": "crane_3",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,9 @@
     claude-tray.url = "github:lorenzolfm/claude-tray";
     claude-tray.inputs.nixpkgs.follows = "nixpkgs";
     claude-tray.inputs.rust-overlay.follows = "rust-overlay";
+    claude-ps.url = "github:lorenzolfm/claude-ps";
+    claude-ps.inputs.nixpkgs.follows = "nixpkgs";
+    claude-ps.inputs.rust-overlay.follows = "rust-overlay";
   };
 
   outputs =
@@ -33,6 +36,7 @@
       sops-nix,
       wt,
       claude-tray,
+      claude-ps,
       ...
     }@inputs:
     {
@@ -44,6 +48,7 @@
             rust-overlay
             wt
             claude-tray
+            claude-ps
             ;
         };
         modules = [

--- a/hosts/desktop/claude-ps.nix
+++ b/hosts/desktop/claude-ps.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  claude-ps,
+  ...
+}:
+
+{
+  environment.systemPackages = [
+    claude-ps.packages.${pkgs.stdenv.hostPlatform.system}.default
+  ];
+}

--- a/hosts/desktop/claude-tray.nix
+++ b/hosts/desktop/claude-tray.nix
@@ -41,15 +41,19 @@ in
 
     # 🔴 NixOS gives user units a sanitized PATH (coreutils, findutils, grep, sed, systemd), so
     # the manager's own PATH from /etc/environment.d does NOT reach the service, and both
-    # binaries the applet shells out to would be missing. Neither is looked up by store path on
-    # purpose:
-    #   - claude-agents, so the producer can be upgraded underneath the applet. ⚠️ It is still
-    #     an imperative `nix profile` install, which is why ~/.nix-profile/bin is on this list.
-    #   - zellij, because click-to-jump speaks to a running server and a pinned build of a
-    #     different version would talk to it wrongly. It must be the same zellij he runs.
+    # binaries the applet shells out to would be missing.
+    #
+    # `claude-ps` is a system package now (`./claude-ps.nix`), so it arrives on
+    # /run/current-system/sw/bin with everything else and moves in the same generation as the
+    # applet — which is what its contract wants, the two agreeing on key names. It used to be an
+    # imperative `nix profile` install, which is why ~/.nix-profile/bin was on this list; that
+    # entry is gone, and nothing the applet calls lives there any more.
+    #
+    # `zellij` is still looked up by name rather than by store path, because click-to-jump speaks
+    # to a **running** server and a pinned build of a different version would talk to it wrongly.
+    # It must be the same zellij he runs.
     environment.PATH = lib.mkForce (
       lib.concatStringsSep ":" [
-        "/home/lorenzo/.nix-profile/bin"
         "/etc/profiles/per-user/lorenzo/bin"
         "/run/current-system/sw/bin"
       ]

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -7,6 +7,7 @@
     ./backup.nix
     ./scb-repo.nix
     ./claude-tray.nix
+    ./rgb.nix
   ];
 
   nixpkgs.overlays = [

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -145,15 +145,28 @@
     alsa.support32Bit = true;
     pulse.enable = true;
     jack.enable = true;
-    # LibrePods (and any AVRCP peer) needs a registered player to accept
-    # play/pause/skip. WirePlumber supplies one itself; bluez's mpris-proxy
-    # is the PulseAudio-era equivalent and the two conflict, so use this
-    # and keep mpris-proxy off.
+    # The AirPods' own play/pause button sends an AVRCP passthrough command,
+    # which only reaches the desktop if something registers a player with
+    # bluez and forwards to MPRIS. Two things can register one and only one
+    # may, or the registration is refused and the button does nothing.
+    #
+    # WirePlumber's dummy player registers but forwards nothing, so it is
+    # explicitly off; mpris-proxy below does the forwarding and is what
+    # actually makes the button work. Verified by testing both in isolation.
     wireplumber.extraConfig."51-bluez-avrcp" = {
       "monitor.bluez.properties" = {
-        "bluez5.dummy-avrcp-player" = true;
+        "bluez5.dummy-avrcp-player" = false;
       };
     };
+  };
+
+  # Bridges AVRCP passthrough from the AirPods to MPRIS, so the button on the
+  # headphones pauses whatever is playing. bluez ships the unit; asDropin
+  # enables it without redefining it (a full definition would collide with
+  # the unit bluez already installs at the same path).
+  systemd.user.services.mpris-proxy = {
+    overrideStrategy = "asDropin";
+    wantedBy = [ "default.target" ];
   };
 
   users.users.lorenzo = {

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -7,6 +7,7 @@
     ./backup.nix
     ./scb-repo.nix
     ./claude-tray.nix
+    ./claude-ps.nix
     ./rgb.nix
   ];
 

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -20,11 +20,27 @@
     # 0001 is upstream PR #417 (open, unmerged), comparing the bluez
     # `device.string` MAC exactly instead. 0002 guards a NULL deref that PR
     # leaves in its new callback. Drop both once #417 reaches nixpkgs.
+    #
+    # 0003 is local. On both pods out librepods set the card profile to "off",
+    # destroying the sink, so the default sink fell back to another device and
+    # on re-insertion the MAC read back as garbage -- resume was unreachable
+    # and taking the AirPods off killed playback rather than pausing it. It
+    # also gated the pause on a flaky blocking D-Bus read that left the resume
+    # list empty. Not filed upstream yet.
+    #
+    # 0004 is local. Chromium exports the MPRIS Player interface with no
+    # introspection XML, and QDBusInterface resolves properties through that
+    # metadata, so every PlaybackStatus read came back empty and librepods
+    # concluded nothing was playing -- ear detection paused nothing at all.
+    # Reads org.freedesktop.DBus.Properties directly instead, as playerctl
+    # does. Not filed upstream yet.
     (_final: prev: {
       librepods = prev.librepods.overrideAttrs (old: {
         patches = (old.patches or [ ]) ++ [
           ../../pkgs/librepods/0001-match-sinks-by-mac-not-name.patch
           ../../pkgs/librepods/0002-guard-null-sink-info.patch
+          ../../pkgs/librepods/0003-pause-on-ear-removal-without-tearing-down-sink.patch
+          ../../pkgs/librepods/0004-read-mpris-properties-without-introspection.patch
         ];
         # The patches are rooted at the repo, but sourceRoot is source/linux.
         patchFlags = [ "-p2" ];

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -46,6 +46,22 @@
         patchFlags = [ "-p2" ];
       });
     })
+    # Ghostty's GTK frontend pulses the OSC 9;4 indeterminate progress bar once
+    # per progress report, and GtkProgressBar paces its animation by the gap
+    # between pulse() calls -- so the bar's speed is whatever rate the program
+    # in the terminal happens to emit at. Claude Code reports about once a
+    # second, which moves the block 10% per second: ten seconds to cross, and a
+    # stall whenever reports pause. The macOS frontend animates its own 1.2s
+    # bounce and ignores the report rate, which is why this only looks wrong on
+    # Linux. 0001 drives the pulse from a 120ms timer instead. Not filed
+    # upstream yet.
+    (_final: prev: {
+      ghostty = prev.ghostty.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [
+          ../../pkgs/ghostty/0001-pulse-progress-bar-on-a-steady-timer.patch
+        ];
+      });
+    })
   ];
 
   boot.loader.systemd-boot.enable = true;

--- a/hosts/desktop/rgb.nix
+++ b/hosts/desktop/rgb.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+{
+  # Motherboard (MSI Mystic Light), RAM, and the NZXT / Cooler Master fan
+  # controllers all expose their LEDs to OpenRGB. `motherboard` is set
+  # explicitly because it otherwise defaults off hardware.cpu.*.updateMicrocode,
+  # which hardware-configuration.nix still reports as intel on this Ryzen box --
+  # that would load i2c-i801 instead of the i2c-piix4 this AMD board needs, and
+  # the DIMMs would never be found.
+  services.hardware.openrgb = {
+    enable = true;
+    motherboard = "amd";
+    # Applied at boot by the server, which reads profiles from its own
+    # StateDirectory -- a profile saved by a client lands in ~/.config/OpenRGB
+    # instead and has to be copied to /var/lib/OpenRGB to be picked up here.
+    startupProfile = "gruvbox";
+  };
+
+  # spd5118 binds the DDR5 SPD hubs and holds the SMBus addresses OpenRGB needs
+  # to reach the DIMMs' RGB controllers (i2cdetect shows them as UU while it is
+  # loaded). Costs the per-DIMM temperature sensors, buys back RAM lighting.
+  boot.blacklistedKernelModules = [ "spd5118" ];
+
+  # i2cdetect, for checking whether the SMBus addresses are actually free.
+  environment.systemPackages = [ pkgs.i2c-tools ];
+}

--- a/pkgs/ghostty/0001-pulse-progress-bar-on-a-steady-timer.patch
+++ b/pkgs/ghostty/0001-pulse-progress-bar-on-a-steady-timer.patch
@@ -1,0 +1,131 @@
+diff --git a/src/apprt/gtk/class/surface.zig b/src/apprt/gtk/class/surface.zig
+--- a/src/apprt/gtk/class/surface.zig
++++ b/src/apprt/gtk/class/surface.zig
+@@ -645,6 +645,7 @@ pub const Surface = extern struct {
+ 
+         // Progress bar
+         progress_bar_timer: ?c_uint = null,
++        progress_bar_pulse_timer: ?c_uint = null,
+ 
+         // True while the bell is ringing. This will be set to false (after
+         // true) under various scenarios, but can also manually be set to
+@@ -1016,6 +1017,7 @@ pub const Surface = extern struct {
+         if (priv.config) |config| {
+             if (!config.get().@"progress-style") {
+                 log.debug("progress_report action blocked by config", .{});
++                self.stopProgressBarPulse();
+                 priv.progress_bar_overlay.as(gtk.Widget).setVisible(@intFromBool(false));
+                 return;
+             }
+@@ -1025,6 +1027,7 @@ pub const Surface = extern struct {
+         switch (value.state) {
+             // Remove the progress bar
+             .remove => {
++                self.stopProgressBarPulse();
+                 progress_bar.as(gtk.Widget).setVisible(@intFromBool(false));
+                 return;
+             },
+@@ -1034,9 +1037,10 @@ pub const Surface = extern struct {
+             .set => {
+                 progress_bar.as(gtk.Widget).removeCssClass("error");
+                 if (value.progress) |progress| {
++                    self.stopProgressBarPulse();
+                     progress_bar.setFraction(computeFraction(progress));
+                 } else {
+-                    progress_bar.pulse();
++                    self.startProgressBarPulse();
+                 }
+             },
+ 
+@@ -1045,16 +1049,17 @@ pub const Surface = extern struct {
+             .@"error" => {
+                 progress_bar.as(gtk.Widget).addCssClass("error");
+                 if (value.progress) |progress| {
++                    self.stopProgressBarPulse();
+                     progress_bar.setFraction(computeFraction(progress));
+                 } else {
+-                    progress_bar.pulse();
++                    self.startProgressBarPulse();
+                 }
+             },
+ 
+             // The state of progress is unknown, so pulse the progress bar to
+             // indicate that things are still happening.
+             .indeterminate => {
+-                progress_bar.pulse();
++                self.startProgressBarPulse();
+             },
+ 
+             // If a progress value was provided, set the progress bar to that value.
+@@ -1062,6 +1067,7 @@ pub const Surface = extern struct {
+             // happening. Otherwise this is mainly used to keep the progress bar on
+             // screen instead of timing out.
+             .pause => {
++                self.stopProgressBarPulse();
+                 if (value.progress) |progress| {
+                     progress_bar.setFraction(computeFraction(progress));
+                 }
+@@ -1092,6 +1098,54 @@ pub const Surface = extern struct {
+         return @intFromBool(glib.SOURCE_REMOVE);
+     }
+ 
++    /// How often we pulse an indeterminate progress bar.
++    ///
++    /// GtkProgressBar advances the block by one `pulse-step` (0.1 by default)
++    /// per `gtk_progress_bar_pulse` call and interpolates that across frames,
++    /// so a steady pulse every 120ms sweeps the trough in roughly 1.2s. That
++    /// matches the bounce duration the macOS apprt animates at.
++    const progress_bar_pulse_interval_ms = 120;
++
++    /// Start pulsing the progress bar, if it isn't pulsing already.
++    ///
++    /// We drive the pulse from our own timer rather than pulsing once per
++    /// progress report, because GtkProgressBar paces the animation by the
++    /// interval between `pulse` calls. Pulsing only on report would hand the
++    /// animation speed to whatever program is running in the terminal: one
++    /// that reports every second moves the block 10% per second, taking ten
++    /// seconds to cross, and one that reports rarely stalls entirely.
++    fn startProgressBarPulse(self: *Self) void {
++        const priv = self.private();
++
++        // Already pulsing. Leave the existing timer alone so that the
++        // animation keeps a steady cadence instead of being restarted (and
++        // visibly jolted) by every progress report that arrives.
++        if (priv.progress_bar_pulse_timer != null) return;
++
++        priv.progress_bar_overlay.pulse();
++        priv.progress_bar_pulse_timer = glib.timeoutAdd(
++            progress_bar_pulse_interval_ms,
++            progressBarPulseTimer,
++            self,
++        );
++    }
++
++    /// Stop pulsing the progress bar. Safe to call when not pulsing.
++    fn stopProgressBarPulse(self: *Self) void {
++        const priv = self.private();
++        const timer = priv.progress_bar_pulse_timer orelse return;
++        if (glib.Source.remove(timer) == 0) {
++            log.warn("unable to remove progress bar pulse timer", .{});
++        }
++        priv.progress_bar_pulse_timer = null;
++    }
++
++    fn progressBarPulseTimer(ud: ?*anyopaque) callconv(.c) c_int {
++        const self: *Self = @ptrCast(@alignCast(ud.?));
++        self.private().progress_bar_overlay.pulse();
++        return @intFromBool(glib.SOURCE_CONTINUE);
++    }
++
+     /// Request that this terminal come to the front and become focused.
+     /// It is up to the embedding widget to react to this.
+     pub fn present(self: *Self) void {
+@@ -1853,6 +1907,8 @@ pub const Surface = extern struct {
+             priv.progress_bar_timer = null;
+         }
+ 
++        self.stopProgressBarPulse();
++
+         if (priv.idle_rechild) |v| {
+             if (glib.Source.remove(v) == 0) {
+                 log.warn("unable to remove idle source", .{});

--- a/pkgs/librepods/0003-pause-on-ear-removal-without-tearing-down-sink.patch
+++ b/pkgs/librepods/0003-pause-on-ear-removal-without-tearing-down-sink.patch
@@ -1,0 +1,36 @@
+diff --git a/linux/media/mediacontroller.cpp b/linux/media/mediacontroller.cpp
+--- a/linux/media/mediacontroller.cpp
++++ b/linux/media/mediacontroller.cpp
+@@ -51,11 +51,13 @@
+ 
+   if (shouldPause && isActiveOutputDeviceAirPods())
+   {
+-    if (getCurrentMediaState() == Playing)
+-    {
+-      LOG_DEBUG("Pausing playback for ear detection");
+-      pause();
+-    }
++    // Do not gate on getCurrentMediaState(): it is a blocking D-Bus property
++    // read that intermittently reports "not playing" for a player that is in
++    // fact playing, which leaves pausedByAppServices empty and makes the
++    // resume below unreachable. pause() already skips any service whose
++    // PlaybackStatus is not "Playing", so the outer check is redundant.
++    LOG_DEBUG("Pausing playback for ear detection");
++    pause();
+   }
+ 
+   // Then handle device profile switching
+@@ -73,7 +75,12 @@
+   else
+   {
+     LOG_INFO("Both AirPods are out of ear");
+-    removeAudioOutputDevice();
++    // Deliberately do NOT call removeAudioOutputDevice() here. It sets the
++    // card profile to "off", which destroys the sink; the default sink then
++    // falls back to another device, so on re-insertion
++    // isActiveOutputDeviceAirPods() reads a non-bluez sink name, and the
++    // resume branch above is skipped. Ear detection should pause playback,
++    // not tear down the audio device.
+   }
+ }
+ 

--- a/pkgs/librepods/0004-read-mpris-properties-without-introspection.patch
+++ b/pkgs/librepods/0004-read-mpris-properties-without-introspection.patch
@@ -1,0 +1,214 @@
+diff --git a/linux/media/mediacontroller.cpp b/linux/media/mediacontroller.cpp
+--- a/linux/media/mediacontroller.cpp
++++ b/linux/media/mediacontroller.cpp
+@@ -10,6 +10,42 @@
+ #include <QRegularExpression>
+ #include <QDBusConnection>
+ #include <QDBusConnectionInterface>
++#include <QDBusMessage>
++#include <QDBusVariant>
++
++namespace {
++
++// Chromium exports org.mpris.MediaPlayer2.Player without any introspection
++// XML. QDBusInterface resolves properties and methods through that metadata,
++// so property("PlaybackStatus") returns an empty variant and every playing
++// player looks stopped -- ear detection then pauses nothing. Calling
++// org.freedesktop.DBus.Properties directly is what playerctl does, and it
++// works whether or not the peer is introspectable.
++QString mprisPlaybackStatus(const QDBusConnection &bus, const QString &service)
++{
++  QDBusMessage msg = QDBusMessage::createMethodCall(
++      service, "/org/mpris/MediaPlayer2",
++      "org.freedesktop.DBus.Properties", "Get");
++  msg << QString("org.mpris.MediaPlayer2.Player") << QString("PlaybackStatus");
++
++  QDBusMessage reply = bus.call(msg, QDBus::Block, 2000);
++  if (reply.type() != QDBusMessage::ReplyMessage || reply.arguments().isEmpty())
++  {
++    return QString();
++  }
++  return reply.arguments().constFirst().value<QDBusVariant>().variant().toString();
++}
++
++bool mprisCall(const QDBusConnection &bus, const QString &service, const QString &method)
++{
++  QDBusMessage msg = QDBusMessage::createMethodCall(
++      service, "/org/mpris/MediaPlayer2",
++      "org.mpris.MediaPlayer2.Player", method);
++  QDBusMessage reply = bus.call(msg, QDBus::Block, 2000);
++  return reply.type() == QDBusMessage::ReplyMessage;
++}
++
++} // namespace
+ 
+ MediaController::MediaController(QObject *parent) : QObject(parent) {
+   m_pulseAudio = new PulseAudioController(this);
+@@ -284,19 +320,7 @@
+       continue;
+     }
+ 
+-    QDBusInterface playerInterface(
+-        service,
+-        "/org/mpris/MediaPlayer2",
+-        "org.mpris.MediaPlayer2.Player",
+-        bus);
+-
+-    if (!playerInterface.isValid())
+-    {
+-      continue;
+-    }
+-
+-    QVariant playbackStatus = playerInterface.property("PlaybackStatus");
+-    if (playbackStatus.isValid() && playbackStatus.toString() == "Playing")
++    if (mprisPlaybackStatus(bus, service) == "Playing")
+     {
+       playingServices << service;
+       LOG_DEBUG("Found playing service: " << service);
+@@ -319,27 +343,14 @@
+ 
+   for (const QString &service : pausedByAppServices)
+   {
+-    QDBusInterface playerInterface(
+-        service,
+-        "/org/mpris/MediaPlayer2",
+-        "org.mpris.MediaPlayer2.Player",
+-        bus);
+-
+-    if (!playerInterface.isValid())
+-    {
+-      LOG_WARN("Service no longer available: " << service);
+-      continue;
+-    }
+-
+-    QDBusReply<void> reply = playerInterface.call("Play");
+-    if (reply.isValid())
++    if (mprisCall(bus, service, "Play"))
+     {
+       LOG_INFO("Resumed playback for: " << service);
+       resumedCount++;
+     }
+     else
+     {
+-      LOG_ERROR("Failed to resume " << service << ": " << reply.error().message());
++      LOG_ERROR("Failed to resume " << service);
+     }
+   }
+ 
+@@ -369,27 +380,15 @@
+       continue;
+     }
+ 
+-    QDBusInterface playerInterface(
+-        service,
+-        "/org/mpris/MediaPlayer2",
+-        "org.mpris.MediaPlayer2.Player",
+-        bus);
+-
+-    if (!playerInterface.isValid())
+-    {
+-      continue;
+-    }
+-
+-    QVariant playbackStatus = playerInterface.property("PlaybackStatus");
+-    LOG_DEBUG("PlaybackStatus for " << service << ": " << playbackStatus.toString());
+-    if (!playbackStatus.isValid() || playbackStatus.toString() != "Playing")
++    const QString playbackStatus = mprisPlaybackStatus(bus, service);
++    LOG_DEBUG("PlaybackStatus for " << service << ": " << playbackStatus);
++    if (playbackStatus != "Playing")
+     {
+       continue;
+     }
+ 
+-    QDBusReply<void> reply = playerInterface.call("Pause");
+     LOG_DEBUG("Pausing service: " << service);
+-    if (reply.isValid())
++    if (mprisCall(bus, service, "Pause"))
+     {
+       LOG_INFO("Paused playback for: " << service);
+       pausedByAppServices << service;
+@@ -397,7 +396,7 @@
+     }
+     else
+     {
+-      LOG_ERROR("Failed to pause " << service << ": " << reply.error().message());
++      LOG_ERROR("Failed to pause " << service);
+     }
+   }
+ 
+diff --git a/linux/media/playerstatuswatcher.cpp b/linux/media/playerstatuswatcher.cpp
+--- a/linux/media/playerstatuswatcher.cpp
++++ b/linux/media/playerstatuswatcher.cpp
+@@ -4,6 +4,42 @@
+ #include <QVariantMap>
+ #include <QDBusReply>
+ #include <QDBusConnectionInterface>
++#include <QDBusMessage>
++#include <QDBusVariant>
++
++namespace {
++
++// Chromium exports org.mpris.MediaPlayer2.Player without any introspection
++// XML. QDBusInterface resolves properties and methods through that metadata,
++// so property("PlaybackStatus") returns an empty variant and every playing
++// player looks stopped -- ear detection then pauses nothing. Calling
++// org.freedesktop.DBus.Properties directly is what playerctl does, and it
++// works whether or not the peer is introspectable.
++QString mprisPlaybackStatus(const QDBusConnection &bus, const QString &service)
++{
++  QDBusMessage msg = QDBusMessage::createMethodCall(
++      service, "/org/mpris/MediaPlayer2",
++      "org.freedesktop.DBus.Properties", "Get");
++  msg << QString("org.mpris.MediaPlayer2.Player") << QString("PlaybackStatus");
++
++  QDBusMessage reply = bus.call(msg, QDBus::Block, 2000);
++  if (reply.type() != QDBusMessage::ReplyMessage || reply.arguments().isEmpty())
++  {
++    return QString();
++  }
++  return reply.arguments().constFirst().value<QDBusVariant>().variant().toString();
++}
++
++bool mprisCall(const QDBusConnection &bus, const QString &service, const QString &method)
++{
++  QDBusMessage msg = QDBusMessage::createMethodCall(
++      service, "/org/mpris/MediaPlayer2",
++      "org.mpris.MediaPlayer2.Player", method);
++  QDBusMessage reply = bus.call(msg, QDBus::Block, 2000);
++  return reply.type() == QDBusMessage::ReplyMessage;
++}
++
++} // namespace
+ 
+ PlayerStatusWatcher::PlayerStatusWatcher(const QString &playerService, QObject *parent)
+     : QObject(parent),
+@@ -32,9 +68,9 @@
+ }
+ 
+ void PlayerStatusWatcher::updateStatus() {
+-    QVariant reply = m_iface->property("PlaybackStatus");
+-    if (reply.isValid()) {
+-        emit playbackStatusChanged(reply.toString());
++    const QString status = mprisPlaybackStatus(QDBusConnection::sessionBus(), m_playerService);
++    if (!status.isEmpty()) {
++        emit playbackStatusChanged(status);
+     }
+ }
+ 
+@@ -54,14 +90,8 @@
+ 
+     for (const QString &service : services) {
+         if (service.startsWith("org.mpris.MediaPlayer2.")) {
+-            QDBusInterface iface(service, "/org/mpris/MediaPlayer2",
+-                               "org.mpris.MediaPlayer2.Player", bus);
+-            
+-            if (iface.isValid()) {
+-                QVariant status = iface.property("PlaybackStatus");
+-                if (status.isValid() && status.toString() == "Playing") {
+-                    return status.toString();
+-                }
++            if (mprisPlaybackStatus(bus, service) == "Playing") {
++                return QStringLiteral("Playing");
+             }
+         }
+     }


### PR DESCRIPTION
## Contents

Four new commits, each self-contained. Two commits that were already sitting
unpushed on local `main` (`3252961` OpenRGB, `4db761c` gitignore) ride along
at the base of the branch — they were already committed, and the working
tree changes here sit on top of them, so they could not be cleanly separated.
Review from `8d9c031` onward for what is actually new.

| Commit | What |
|---|---|
| `8d9c031` | claude-ps becomes a flake input + system package |
| `f1c00c9` | Two librepods patches so ear detection pauses/resumes |
| `a5d61c3` | Ghostty progress-bar pulse driven by a timer |
| `8e60991` | AirPods play/pause button via mpris-proxy |

## claude-ps as a system package

It was an imperative `nix profile` install, so it could drift out of step
with claude-tray. The applet and the producer have to agree on key names, so
they should move together in one generation. As a system package it lands on
`/run/current-system/sw/bin`, which lets `claude-tray.nix` drop
`~/.nix-profile/bin` from the unit's forced PATH entirely — nothing the
applet shells out to lives there any more.

`flake.lock` churn is mostly mechanical: transitive nodes for claude-ps
(crane, flake-parts, nixpkgs-lib) plus renumbering. The genuine bumps are
`claude-tray`, `rust-overlay`, and claude-tray's pinned `nixpkgs`.

## librepods (0003, 0004)

Both local, neither filed upstream yet. Together they're why taking the
AirPods off did not do the right thing:

- **0003** — with both pods out, librepods set the card profile to `off`,
  destroying the sink. The default sink fell back to another device, and on
  re-insertion the MAC read back as garbage, so resume was unreachable and
  removing the AirPods *killed* playback instead of pausing it.
- **0004** — Chromium exports the MPRIS Player interface with no
  introspection XML, and `QDBusInterface` resolves properties through that
  metadata. Every `PlaybackStatus` read came back empty, so librepods
  concluded nothing was playing and paused nothing at all.

## Ghostty progress bar

The GTK frontend pulses the OSC 9;4 indeterminate bar once per progress
report, and `GtkProgressBar` paces its animation by the gap between
`pulse()` calls — so the bar's speed was whatever rate the program in the
terminal emitted at. Claude Code reports roughly once a second, moving the
block 10% per second: ten seconds to cross, and a stall whenever reports
paused. The macOS frontend animates its own 1.2s bounce and ignores the
report rate, which is why this only looked wrong on Linux.

## AVRCP / mpris-proxy

The old comment had this backwards. The button sends an AVRCP passthrough
command, which only lands if something registers a player with bluez *and*
forwards to MPRIS. Two things can register one and only one may, or the
registration is refused. WirePlumber's dummy player registers but forwards
nothing; mpris-proxy is what actually does the work. So the dummy is now
explicitly off and mpris-proxy is enabled — as a drop-in, since bluez
already ships the unit at that path. Verified by testing each in isolation.

## Note

Nix files are parse-checked only (`nix-instantiate --parse`). No
`nixos-rebuild` was run as part of preparing this branch.
