### PR TITLE
desktop: open-source contribution board, plus SSH and ghostty fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1787952139,
-        "narHash": "sha256-NVFDQ1zolO+1o3YfBuoldkYXyDQM80xGjMd1M6XSWT4=",
+        "lastModified": 1788206511,
+        "narHash": "sha256-73a93NrKnP1DsNzy2FrdOFKXSe5I9bG/B0ytQepXUBg=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "610372fec14515281ef2c4bb6f383fab7881e1ee",
+        "rev": "648cf2ac8393d384cc4430d850dee4dd76f50d6c",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788063168,
-        "narHash": "sha256-102+uIKx+QjJvCb0RagBP93yL1bjBbk+7ps36hogYs4=",
+        "lastModified": 1788191149,
+        "narHash": "sha256-zpI/jh/Ts/yyEvGljKmHR5y8rwTLoUukDX3ZIOXaG/M=",
         "owner": "lorenzolfm",
         "repo": "claude-ps",
-        "rev": "f092e0d2ced84d0d69320aeeec71a0cf21ae1287",
+        "rev": "e9f970a6ea7a20aeff360ad7b92637797c882886",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788063204,
-        "narHash": "sha256-tDAOGHl2AfjPS7gCqaS9BaOkUFjc9qKci77A6Nr3vCc=",
+        "lastModified": 1788139435,
+        "narHash": "sha256-6ixCGEuBWkPmAAAQM/zHmWvdJpSVTIJEtHcm35M69Iw=",
         "owner": "lorenzolfm",
         "repo": "claude-tray",
-        "rev": "5b81aa376826c9f61ed30fda6a4def63731a4cef",
+        "rev": "fef6790db6f4bc3270fb8551c63b46e6d7175eb2",
         "type": "github"
       },
       "original": {
@@ -452,11 +452,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {
@@ -487,11 +487,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788077403,
-        "narHash": "sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4+7Ur4icKssD4Wc=",
+        "lastModified": 1788165049,
+        "narHash": "sha256-en4IoUeCqvq9F66YhwOrUFw1nc70OBhrJwrzfalezvY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "89e26eeaafa88a2ede4778734acc794ff0299beb",
+        "rev": "d03cd474bd97389dcc2e8cd3b3bb6b8c6e346b1a",
         "type": "github"
       },
       "original": {

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -8,6 +8,7 @@
     ./scb-repo.nix
     ./claude-tray.nix
     ./claude-ps.nix
+    ./oss-board.nix
     ./rgb.nix
   ];
 

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -178,6 +178,8 @@
     description = "Lorenzo";
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID/67UYdIgV7PwpayA/4Ogc7u84q8FQ5AKrLLRX7q3zT lorenzo@lorenzo-mac"
+      # Termius on the iPhone, for SSH over Tailscale from outside the LAN.
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC2msniVULYTITZN4q2LXHkN4AZV97ttv6hW507wuWB6 lorenzo@iphone-termius"
     ];
     extraGroups = [
       "networkmanager"
@@ -289,6 +291,15 @@
     # xdg-desktop-portal (Requisite=graphical-session.target) can never
     # start: no portals, and GTK apps ignore the dark color-scheme.
     withUWSM = true;
+  };
+
+  # Port 22 is only open on tailscale0 (see networking.firewall above), so
+  # reaching sshd already requires being on the tailnet. Keys-only on top of
+  # that means a tailnet device alone is not enough to log in. The physical
+  # console stays available if a key is ever lost.
+  services.openssh.settings = {
+    PasswordAuthentication = false;
+    KbdInteractiveAuthentication = false;
   };
 
   services.fail2ban = {

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -47,14 +47,18 @@
       });
     })
     # Ghostty's GTK frontend pulses the OSC 9;4 indeterminate progress bar once
-    # per progress report, and GtkProgressBar paces its animation by the gap
-    # between pulse() calls -- so the bar's speed is whatever rate the program
-    # in the terminal happens to emit at. Claude Code reports about once a
-    # second, which moves the block 10% per second: ten seconds to cross, and a
-    # stall whenever reports pause. The macOS frontend animates its own 1.2s
-    # bounce and ignores the report rate, which is why this only looks wrong on
-    # Linux. 0001 drives the pulse from a 120ms timer instead. Not filed
-    # upstream yet.
+    # per progress report, and GtkProgressBar paces the block by the gap between
+    # the last two pulse() calls -- so the bar's speed is whatever rate the
+    # program in the terminal happens to emit at. Claude Code reports once per
+    # turn, and on that very first pulse there is no previous pulse to measure
+    # against: GtkProgressBar divides by the monotonic clock instead, so the
+    # block does not move at all. Measured on stock 1.3.1: 0px over 14s, then
+    # the bar times out. The macOS frontend animates its own 1.2s bounce and
+    # ignores the report rate, which is why this only looks wrong on Linux.
+    # 0001 drives the pulse from a 120ms timer instead.
+    #
+    # Write-up and reproduction: ~/Projects/misc/ghostty-osc94-progress-bar.
+    # Drafted for upstream, not filed yet -- blocked on checking the macOS half.
     (_final: prev: {
       ghostty = prev.ghostty.overrideAttrs (old: {
         patches = (old.patches or [ ]) ++ [

--- a/hosts/desktop/oss-board.nix
+++ b/hosts/desktop/oss-board.nix
@@ -1,0 +1,142 @@
+# Twice-daily open-source contribution board updater.
+#
+# Mirrors the borgmatic pattern in backup.nix: a systemd timer with
+# Persistent = true, secrets via sops-nix, and an uptime-kuma push heartbeat so
+# a job that silently stops updating the board is visible.
+#
+# Import from hosts/desktop/configuration.nix:
+#   imports = [ ./oss-board.nix ];
+# `claude-code` arrives via specialArgs in flake.nix, the same way
+# claude-tray.nix and claude-ps.nix receive theirs.
+{
+  config,
+  pkgs,
+  lib,
+  claude-code,
+  ...
+}:
+let
+  user = "lorenzo";
+  home = "/home/${user}";
+  projectDir = "${home}/Projects/misc/opensource";
+  board = "${home}/Documents/Vault/Opensource/Tasks.md";
+
+  # Telegram chat id is the openclaw allowlist entry -- not a secret.
+  telegramChatId = "507707481";
+
+  pushUrlFile = "${home}/.config/nixos/local-secrets/uptime-kuma-push-oss-board";
+  hasPushUrl = builtins.pathExists pushUrlFile;
+  pushUrl =
+    if hasPushUrl then builtins.replaceStrings [ "\n" ] [ "" ] (builtins.readFile pushUrlFile) else "";
+
+  # systemd services get a minimal PATH -- /run/current-system/sw/bin is NOT on
+  # it. Every binary the run shells out to must be listed here explicitly, or
+  # the model passes fail open and the board silently degrades to ranking order.
+  runtimeDeps = [
+    claude-code.packages.${pkgs.system}.claude-code
+  ]
+  ++ (with pkgs; [
+    python3
+    gh
+    git
+    nix
+    coreutils
+    openssh
+    cacert
+  ]);
+in
+{
+  # Read-only GitHub token, minted as a fine-grained PAT with no write scopes.
+  # The read-only guarantee is structural: even a misbehaving run cannot comment,
+  # claim, or open a PR as lorenzolfm.
+  sops.secrets."oss-board-github-token" = {
+    owner = user;
+    mode = "0400";
+  };
+  sops.secrets."oss-board-telegram-token" = {
+    owner = user;
+    mode = "0400";
+  };
+
+  systemd.services.oss-board = {
+    description = "Update the open-source contribution board";
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+
+    path = runtimeDeps;
+
+    environment = {
+      HOME = home;
+      # `nix eval` for the nixpkgs bump check, and TLS for the API calls.
+      NIX_PATH = "nixpkgs=flake:nixpkgs";
+      SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      TELEGRAM_CHAT_ID = telegramChatId;
+      TELEGRAM_BOT_TOKEN_FILE = config.sops.secrets."oss-board-telegram-token".path;
+      # openclaw's /api/channels/telegram exists (answers 401, not 404) but its
+      # request body shape is unconfirmed. Flip to "1" once verified.
+      OPENCLAW_ENABLED = "0";
+      OPENCLAW_URL = "https://oc.lorenzo.sh";
+    }
+    // lib.optionalAttrs hasPushUrl { UPTIME_KUMA_PUSH_URL = pushUrl; };
+
+    serviceConfig = {
+      Type = "oneshot";
+      User = user;
+      Group = "users";
+      WorkingDirectory = projectDir;
+
+      # GH_TOKEN must come from the file, not the unit, so it never lands in the
+      # journal or in /proc/*/environ.
+      ExecStart = pkgs.writeShellScript "oss-board-run" ''
+        set -euo pipefail
+        export GH_TOKEN="$(cat ${config.sops.secrets."oss-board-github-token".path})"
+        exec ${pkgs.python3}/bin/python3 ${projectDir}/run.py \
+          --board ${lib.escapeShellArg board} \
+          --notify
+      '';
+
+      # A scan plus the model passes; generous ceiling, then give up rather than
+      # overlap with the next timer firing.
+      TimeoutStartSec = "45min";
+
+      Nice = 10;
+      IOSchedulingClass = "idle";
+
+      # Hardening. It needs the vault, the project dir, and ~/Projects/misc for
+      # the stranded-branch scan -- and nothing else writable.
+      PrivateTmp = true;
+      ProtectSystem = "strict";
+      ProtectHome = "read-only";
+      ReadWritePaths = [
+        "${home}/Documents/Vault/Opensource"
+        "${projectDir}/state"
+      ];
+      NoNewPrivileges = true;
+      ProtectKernelTunables = true;
+      ProtectKernelModules = true;
+      ProtectControlGroups = true;
+      RestrictSUIDSGID = true;
+      RestrictNamespaces = true;
+      LockPersonality = true;
+      MemoryDenyWriteExecute = false; # the model CLI needs a JIT-capable heap
+      SystemCallArchitectures = "native";
+    };
+  };
+
+  systemd.timers.oss-board = {
+    description = "Update the open-source contribution board twice daily";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      # Off-peak minutes on purpose: :00 and :30 are where every scheduler lands.
+      OnCalendar = [
+        "08:07"
+        "19:23"
+      ];
+      # A run missed while the desktop was off fires on next boot rather than
+      # being skipped -- the desktop is not always awake.
+      Persistent = true;
+      RandomizedDelaySec = "5m";
+      Unit = "oss-board.service";
+    };
+  };
+}

--- a/hosts/desktop/secrets.yaml
+++ b/hosts/desktop/secrets.yaml
@@ -1,18 +1,20 @@
 borg-passphrase: ENC[AES256_GCM,data:L3zeB/XhPWziCzMu8DnxZP3Fx3zn3YBqkhLAa8gFAXBLc6GlSnHiIuNPszE=,iv:ghELHe0TeOVB4GASpIypf/GqLd1Keder4ovXC04TfYE=,tag:4+J2YqQt9M+lgjv8L7fm3g==,type:str]
 borg-ssh-key-homelab2: ENC[AES256_GCM,data:C1lBqTWtoFRzV+1E+xpC0pUh0Zn0+aC/D4e6b+l7d9/pN6LkxyD4ul6I5osgPmnW9I7oYCvfp7Prwac/Wn68A/tUQ+PGmHxHhRN4pHJ2OaU2I+qfUVyfqthusV8wy1KbCS8j1L74ygMJFKUH6Tcgsm5+JWVwAx4TPkPzI5DgU6c+ZH9q4YmQ1Q0SCT+YI9uOPKPHacO89Cu1FtpsQqYRr4f53rjt2RYUvB53T2nyipLuIKn5449hNC34kPui7t8Ky6znkKrj9voTgC3zec1DmH1zt+2eUFY71q5EAixudYUoePoSF2ifI6bo84g8McuOUk07JzOct3SyovAigeo8Xlb8E/f9RHO9EnOa4aQl6zKX5FnfNrSagxkGxD8ZS2n3rzaGKXExJhMC3NUXBODe3ZB7Vi+GdOC3Px12N8pZ5FJYD23mzC5OmjOQNyWtBBHo+X550t0fOtnoZNBJa+EGE73ablRJ871BQvMaaCQWE1DN6shFVMVXiab3LHh4NWZx1BQuhhgeJ4bbCIdjHr5CwwdMjS/TU7pbr2WdTAPBhkOIHaQ=,iv:1lejIlkRWiYyM7RJu9XnKWQw3ubL9QtOC+j3HejUeEg=,tag:/2pL2N3ZWR8HezB2l7Lg7w==,type:str]
 borg-ssh-key-contabo: ENC[AES256_GCM,data:aQUbGIOXogfYPHw/AAEenkb6Yr2yN6ZIK0mD9QUu8U9f98stkEhgIUWludXDp/Wh4esDdeie0LWZhVBNK1o3BO5ZSHkbK3CRs3wc/eFQiBI7AcoZXHQM25nsRG61gxzru/fRyhOQ272zaIhPCQrrUDAXrBH07VWd4LG0v9XEZCKVyCosTbDToMxRocehR4oNUo5IkglbSJWpqiHSUf9MGDfanJMQh8RmJxHLk1OmcW1pVqgyavqeYFxCSiTyVPolvrdJhI6NpBUR7+gqcOIQTX6gIXw7ob6n7hNzxVrdbwebuA77ERlmNPTVF6kK97afyjsWCJb1f9VN21DEvnreHv3iXdi4skJ/lpPw1sf6TIpyYL7tMz5VOC+8BiRo16koZbPH1FkjS2L7qMjehNhCvFZsG1OeH+7NSVSLZU9fdkwxLie0yMu4RZrCfPu6iFI8bd81uUUGJXtnPvd/wy4YAx+/JwcIIfzTM6UR3n1MxADSNEbkdxUH3l8tQiuZ6deSjHXYPXkKKAoGWqZdI4zfvdJ1zME4yPg6LM0mRDPtFY26Qso=,iv:m2MTk3w85hp2EWEMIEaNjF4xuDw1cna5ooVkACEukwA=,tag:6aA3mWsXFZel0Y/wFhd++w==,type:str]
+oss-board-github-token: ENC[AES256_GCM,data:Fe5+XFcQN0VD+o4jf2eiH6zZDb/arY2CwMQd83tckKlSAxLO5y+xv180ZiEpiVPuN6m+2HrpGQe+fCUQYlfa3SRz93uZGhZOJJRuQVKc3ciT2rn9jgTtPJ3RPMXs,iv:HCjOt5BpUT2TmvYWgiT9QkAa1bSwerVXqSDpONv+ho0=,tag:jX3hVbaOnWTFnE5oLcUsNg==,type:str]
+oss-board-telegram-token: ENC[AES256_GCM,data:US+SwGc1WAO29N9R75FITvL1uksGC435un0lZjwyuJBvWQs7DYF36RBKTm9A5w==,iv:KSGbSBdC2oEz3sOrbHc7EBqQ/wk8JoeCHdGK+is5220=,tag:NfQ5gPpaulfbZKftsgjPrQ==,type:str]
 sops:
-  age:
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtR0I5WkNyUmVaR21zb2xQ
-        TlovVDk0UnlvSkJsaXkvS0IwN0tCdTBXelc4CmdhbkpyU25aRkJ6UGVMVWkvS3pN
-        bTN3ZE5pazNkZG0xM3RLWHpMTDVVcmMKLS0tIGx2UW9hTFFLVDNqUzhmZTZjNXJT
-        RDJ4MkhHUk0vaXY5S1NIOTUzTEo3SE0KW+miGQASvXNmk5nAsII13b/Kc/rlaZBw
-        7dFkCjqck1u+tdaayrTwRUlztm+KKcWq0/rYpv0S5qXSOdMOlKqaXg==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1hpkjwe2nx885kc2j4cdywf465st7ulr52xrjteje6xp2pmsuje5q3ryepa
-  lastmodified: "2026-07-22T17:13:28Z"
-  mac: ENC[AES256_GCM,data:HLjTeaVY1/NKCrYAwBzBGhZ+Tu4upc/PFKdONa9XuHdq1DYBBZvkm1I3NoV/WF5els70JPEpdzgTfb7c3V10aZQDiiF6IasvuJWitYbBY3rIyLAXcBTdj7ym6KDmXUk/ZvKHaxEE1iwKBCRgI/nMnKEQqMP1q3vQStJ7z/BHPKs=,iv:BQkMEA6l8S0xV0APaF9n8Blg5ZSBgQiHQR97hioFSrs=,tag:kutltNVcsdzNYmIYM6E5lw==,type:str]
-  unencrypted_suffix: _unencrypted
-  version: 3.13.2
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtR0I5WkNyUmVaR21zb2xQ
+            TlovVDk0UnlvSkJsaXkvS0IwN0tCdTBXelc4CmdhbkpyU25aRkJ6UGVMVWkvS3pN
+            bTN3ZE5pazNkZG0xM3RLWHpMTDVVcmMKLS0tIGx2UW9hTFFLVDNqUzhmZTZjNXJT
+            RDJ4MkhHUk0vaXY5S1NIOTUzTEo3SE0KW+miGQASvXNmk5nAsII13b/Kc/rlaZBw
+            7dFkCjqck1u+tdaayrTwRUlztm+KKcWq0/rYpv0S5qXSOdMOlKqaXg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1hpkjwe2nx885kc2j4cdywf465st7ulr52xrjteje6xp2pmsuje5q3ryepa
+    lastmodified: "2026-09-01T13:41:43Z"
+    mac: ENC[AES256_GCM,data:atkANsDXU/iy5CdCXIa8h26WiAXUqzqAYB9Ec4QNx814WKIaZZJGjnatHplrgksBra/cRa902vIPfKsCskizLi5rNlL+C4tsDoPenTVW4JYNMYCdNOMq6vdQVOfkEfspzIajt9GNKJOM2fUWL6+k1Q+FFZPxEvUyG/StfiF7ZB0=,iv:U1jFFQPOjNTlfclxi7NREa9Q7+PpcHQxTFZhjcJlmqY=,tag:qxtIvDNZWx2vVzRN1TvaRA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.2

--- a/pkgs/ghostty/0001-pulse-progress-bar-on-a-steady-timer.patch
+++ b/pkgs/ghostty/0001-pulse-progress-bar-on-a-steady-timer.patch
@@ -71,20 +71,20 @@ diff --git a/src/apprt/gtk/class/surface.zig b/src/apprt/gtk/class/surface.zig
  
 +    /// How often we pulse an indeterminate progress bar.
 +    ///
-+    /// GtkProgressBar advances the block by one `pulse-step` (0.1 by default)
-+    /// per `gtk_progress_bar_pulse` call and interpolates that across frames,
-+    /// so a steady pulse every 120ms sweeps the trough in roughly 1.2s. That
-+    /// matches the bounce duration the macOS apprt animates at.
++    /// GtkProgressBar paces the block by the gap between the last two
++    /// `gtk_progress_bar_pulse` calls, crossing the trough in 10-20x that
++    /// gap. At 120ms that measures ~1.7s a crossing, near the 1.2s bounce
++    /// the macOS apprt animates.
 +    const progress_bar_pulse_interval_ms = 120;
 +
 +    /// Start pulsing the progress bar, if it isn't pulsing already.
 +    ///
 +    /// We drive the pulse from our own timer rather than pulsing once per
 +    /// progress report, because GtkProgressBar paces the animation by the
-+    /// interval between `pulse` calls. Pulsing only on report would hand the
-+    /// animation speed to whatever program is running in the terminal: one
-+    /// that reports every second moves the block 10% per second, taking ten
-+    /// seconds to cross, and one that reports rarely stalls entirely.
++    /// interval between `pulse` calls. Pulsing only on report hands the
++    /// speed to whatever program is running: one reporting every second
++    /// takes 10-20s to cross, and one reporting a single time never moves
++    /// at all -- its first pulse divides by the monotonic clock, not a gap.
 +    fn startProgressBarPulse(self: *Self) void {
 +        const priv = self.private();
 +


### PR DESCRIPTION
Five independent changes, one per commit -- reviewable in order.

| Commit | What |
|---|---|
| `ghostty:` | Corrects the OSC 9;4 progress-bar note. The patch is unchanged; only the diagnosis is. Measuring stock 1.3.1 showed the block does not move *at all* on the first pulse (0px over 14s), rather than merely moving at the emitter's rate. |
| `desktop:` SSH | Authorizes the Termius key for access over Tailscale, and disables password + keyboard-interactive auth. Port 22 is already tailscale0-only, so this makes a tailnet device alone insufficient to log in. Physical console still works if a key is lost. |
| `desktop:` pi-coding-agent | One package. |
| `desktop:` oss-board | The new timer. See below. |
| `chore:` flake.lock | Routine bump. |

## The board

A systemd timer that scans 91 repos twice daily and maintains an obsidian-kanban board in the vault. The job lives in [`lorenzolfm/oss-board`](https://github.com/lorenzolfm/oss-board); this PR is only the unit that drives it.

Modelled on `backup.nix` -- `Persistent = true`, sops-nix credentials, uptime-kuma push heartbeat.

Two things a reviewer should not "simplify":

- **`claude-code` arrives via `specialArgs` and goes on the unit's `path`.** systemd gives services a minimal PATH without `/run/current-system/sw/bin`, and the failure is silent -- the run degrades to ranking order and still writes the board, so the model step would just never happen.
- **`GH_TOKEN` is read from the secret file inside `ExecStart`**, not set in `environment`, so it never reaches the journal or `/proc/*/environ`.

Both secrets set `owner` and `mode = "0400"` because the unit runs as `lorenzo`; `backup.nix` omits `owner` only because borgmatic runs as root.

## Notes

- `hosts/desktop/secrets.yaml` is the sops file, re-encrypted with two new keys. The diff is noise; the plaintext addition is two tokens.
- Already built and switched locally: timer is `active (waiting)`, next fire 19:25.
- Verified `claude-code-2.1.252` is on the unit PATH and both secrets resolve under `/run/secrets/`.