### PR TITLE
desktop: GTK4 renderer fix, plus oss-board runs on its timer only

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1788206511,
-        "narHash": "sha256-73a93NrKnP1DsNzy2FrdOFKXSe5I9bG/B0ytQepXUBg=",
+        "lastModified": 1788303707,
+        "narHash": "sha256-ICEHLJAM480kNrsOQ+DPWWV3XFJUDc6/n/PPcjAuRR8=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "648cf2ac8393d384cc4430d850dee4dd76f50d6c",
+        "rev": "7f0aeb2f0c6cf1ca2bf3b0b76b823b24b04b5b21",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788191149,
-        "narHash": "sha256-zpI/jh/Ts/yyEvGljKmHR5y8rwTLoUukDX3ZIOXaG/M=",
+        "lastModified": 1788262394,
+        "narHash": "sha256-IMfdw+jNS3Rai7y6TENF9f1OmTdbsJoQV9Arl1veSoQ=",
         "owner": "lorenzolfm",
         "repo": "claude-ps",
-        "rev": "e9f970a6ea7a20aeff360ad7b92637797c882886",
+        "rev": "5fa9d72c9929de5f0d08f6d702954768be65130b",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788139435,
-        "narHash": "sha256-6ixCGEuBWkPmAAAQM/zHmWvdJpSVTIJEtHcm35M69Iw=",
+        "lastModified": 1788262399,
+        "narHash": "sha256-3DCwvmRNkOt67IBjxxKNIxxwXKKK6JEdR3tOi+DWWk0=",
         "owner": "lorenzolfm",
         "repo": "claude-tray",
-        "rev": "fef6790db6f4bc3270fb8551c63b46e6d7175eb2",
+        "rev": "2739f6c2aaf4a50de2519151078544464a06ac0c",
         "type": "github"
       },
       "original": {
@@ -487,11 +487,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788165049,
-        "narHash": "sha256-en4IoUeCqvq9F66YhwOrUFw1nc70OBhrJwrzfalezvY=",
+        "lastModified": 1788332415,
+        "narHash": "sha256-BTFrmyh0oaVDsvA9NNw0YpbbeppTwU0t70iVx672Ew8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d03cd474bd97389dcc2e8cd3b3bb6b8c6e346b1a",
+        "rev": "860d7c835ab91bfc8972b67092f5f2db8e9390a0",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786629091,
-        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
+        "lastModified": 1788337237,
+        "narHash": "sha256-gkSH8VUtCo6hnysNmb9DbTuDepH2t5pv+QWjP75xKAk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
+        "rev": "fbf759290e0cb0a98dfc813a4eb7d53ad1dacb57",
         "type": "github"
       },
       "original": {

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -214,6 +214,13 @@
   # apps built without the wayland plugin.
   environment.sessionVariables.QT_QPA_PLATFORM = "wayland;xcb";
 
+  # GTK 4.22 defaults to the Vulkan renderer, which here enumerates only the AMD
+  # iGPU (card1) and never the NVIDIA card driving both monitors. GTK renders on
+  # a GPU wired to no display and hands Hyprland a buffer it cannot sample, so
+  # every GTK4 app (Files, gnome-text-editor) maps a solid black window. Use the
+  # GL renderer instead.
+  environment.sessionVariables.GSK_RENDERER = "ngl";
+
   environment.systemPackages = with pkgs; [
     (appimage-run.override {
       extraPkgs = pkgs: [ pkgs.xorg.libxshmfence ];

--- a/hosts/desktop/oss-board.nix
+++ b/hosts/desktop/oss-board.nix
@@ -63,6 +63,12 @@ in
     after = [ "network-online.target" ];
     wants = [ "network-online.target" ];
 
+    # The timer owns when this runs. Without this, a rebuild that changes the
+    # unit stops an in-flight scan and restarts it -- and since it is oneshot,
+    # `nixos-rebuild` then blocks on the whole scan (up to TimeoutStartSec).
+    # A changed definition still lands in /etc and takes effect on next firing.
+    restartIfChanged = false;
+
     path = runtimeDeps;
 
     environment = {


### PR DESCRIPTION
Three independent changes, one per commit -- reviewable in order.

| Commit | What |
|---|---|
| `desktop:` GTK4 | `GSK_RENDERER=ngl`. GTK 4.22's Vulkan default renders on the wrong GPU here and every GTK4 window comes up solid black. |
| `desktop:` oss-board | `restartIfChanged = false`. Stops `nixos-rebuild` from killing an in-flight scan and then blocking on the restarted one. See below. |
| `chore:` flake.lock | Routine bump. |

## The rebuild hang

The board is supposed to run twice daily on its timer and nothing else. It was also running on every `nixos-rebuild switch` that touched its definition, because the unit had the default `restartIfChanged`: activation stops a changed unit and starts it again if it had been running.

That is bad twice over. A scan already in flight gets killed and restarted from scratch -- and since the unit is `Type = "oneshot"`, `systemctl start` does not return until `ExecStart` exits, so the rebuild itself blocks on a full 91-repo scan plus the model passes. `TimeoutStartSec = "45min"` is the only ceiling.

Caught it happening: the timer fired at 08:09:16, a rebuild at 08:14:39 stopped and restarted the unit, and activation then sat on

```
JOB   UNIT              TYPE  STATE
18255 oss-board.service start running
```

with `gh api graphql` mid-batch, for as long as I let it.

`restartIfChanged = false` renders `X-RestartIfChanged=false`, which `switch-to-configuration` reads to put the unit in its *skip* set -- neither stopped nor started during activation. Nothing is lost by not restarting: the new definition still lands in `/etc/systemd/system` and takes effect at the next firing.

One thing a reviewer might reach for and shouldn't: `stopIfChanged = false` is *not* the fix. It only swaps stop+start for `systemctl restart`, which still runs the scan and still blocks.

## Notes

- Because the new unit itself carries the marker, the next rebuild already skips it -- there is no one-time hit to get past.
- Verified the rendered unit: `nix eval .#nixosConfigurations.nixos.config.systemd.units."oss-board.service".text` emits `X-RestartIfChanged=false` alongside `Type=oneshot`.
- Verified `X-RestartIfChanged` is among the markers the switch tool actually reads, rather than trusting the option name.
- Full config evaluates; `nixfmt --check` clean on both touched files.
- Not yet switched -- `nixos-rebuild` still to run on the desktop.
